### PR TITLE
feat/multi-provider-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # PR Description Generator
 
-PR Description Generator is a Go-based CLI tool that automatically generates pull request descriptions by comparing your current branch with any branch. It supports multiple LLM providers including local Ollama models, OpenAI, and Anthropic to generate professional PR descriptions based on your actual code changes.
+PR Description Generator is a Go-based CLI tool that automatically generates pull request descriptions by comparing your current branch with any branch. It supports multiple LLM providers including local Ollama models, OpenAI, Anthropic, and DeepSeek to generate professional PR descriptions based on your actual code changes.
 
 ## Features
 
 - Automatically compares current branch with any branch
 - Extracts git diff and commit history
 - Generates professional PR descriptions using multiple LLM providers
-- Supports Ollama (local), OpenAI, and Anthropic
+- Supports Ollama (local), OpenAI, Anthropic, and DeepSeek
 - Outputs markdown format for easy integration with GitHub CLI
 - No manual input required - everything is calculated from your git repository
 - Config file support for persistent settings
@@ -23,6 +23,7 @@ PR Description Generator is a Go-based CLI tool that automatically generates pul
   - **Ollama**: Local models (default: qwen2.5-coder:14b-instruct-q8_0)
   - **OpenAI**: API key and model (e.g., gpt-4, gpt-3.5-turbo)
   - **Anthropic**: API key and model (e.g., claude-3-sonnet-20240229)
+  - **DeepSeek**: API key and model (e.g., deepseek-chat, deepseek-coder)
 
 ## Installation
 
@@ -72,6 +73,14 @@ temperature=0.1
 provider=anthropic
 api_key=your_anthropic_api_key_here
 model=claude-3-sonnet-20240229
+temperature=0.1
+```
+
+**For DeepSeek:**
+```ini
+provider=deepseek
+api_key=your_deepseek_api_key_here
+model=deepseek-chat
 temperature=0.1
 ```
 
@@ -132,9 +141,9 @@ On Linux:
 
 Available options:
 
-- `-provider`: LLM provider (ollama, openai, anthropic)
+- `-provider`: LLM provider (ollama, openai, anthropic, deepseek)
 - `-model`: Model to use (varies by provider)
-- `-api-key`: API key for the provider (required for OpenAI/Anthropic)
+- `-api-key`: API key for the provider (required for OpenAI/Anthropic/DeepSeek)
 - `-base-url`: Base URL for the provider (optional, defaults vary by provider)
 - `-temperature`: Temperature for generation (default: 0.1)
 - `-branch`: Branch to compare current changes against (default: `main`)
@@ -155,6 +164,11 @@ Available options:
 **Using Anthropic:**
 ```bash
 ./gopr -provider anthropic -model claude-3-sonnet-20240229 -api-key your_api_key_here
+```
+
+**Using DeepSeek:**
+```bash
+./gopr -provider deepseek -model deepseek-chat -api-key your_api_key_here
 ```
 
 **Enable verbose output:**
@@ -192,6 +206,11 @@ Based on testing, these models perform best for PR description generation:
 1. **claude-3-sonnet-20240229** - Excellent code analysis and PR descriptions
 2. **claude-3-haiku-20240307** - Fast and efficient for smaller changes
 3. **claude-3-opus-20240229** - Highest quality but slower responses
+
+### DeepSeek Models
+1. **deepseek-chat** - Excellent code understanding and PR descriptions
+2. **deepseek-coder** - Specialized for code-related tasks
+3. **deepseek-chat-33b** - High-quality responses with good performance
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # PR Description Generator
 
-PR Description Generator is a Go-based CLI tool that automatically generates pull request descriptions by comparing your current branch with any branch. It uses a local Ollama instance to generate professional PR descriptions based on your actual code changes.
+PR Description Generator is a Go-based CLI tool that automatically generates pull request descriptions by comparing your current branch with any branch. It supports multiple LLM providers including local Ollama models, OpenAI, and Anthropic to generate professional PR descriptions based on your actual code changes.
 
 ## Features
 
 - Automatically compares current branch with any branch
 - Extracts git diff and commit history
-- Generates professional PR descriptions using local Ollama models
+- Generates professional PR descriptions using multiple LLM providers
+- Supports Ollama (local), OpenAI, and Anthropic
 - Outputs markdown format for easy integration with GitHub CLI
 - No manual input required - everything is calculated from your git repository
 - Config file support for persistent settings
@@ -18,8 +19,10 @@ PR Description Generator is a Go-based CLI tool that automatically generates pul
 
 - Go 1.20+
 - Git repository
-- Ollama installed and running locally (or remotely)
-- An Ollama model (default: qwen2.5-coder:14b-instruct-q8_0)
+- One of the following LLM providers:
+  - **Ollama**: Local models (default: qwen2.5-coder:14b-instruct-q8_0)
+  - **OpenAI**: API key and model (e.g., gpt-4, gpt-3.5-turbo)
+  - **Anthropic**: API key and model (e.g., claude-3-sonnet-20240229)
 
 ## Installation
 
@@ -46,11 +49,30 @@ PR Description Generator is a Go-based CLI tool that automatically generates pul
 
 ### Config File
 
-Create a `.goprrc` file in your project root or home directory with:
+Create a `.goprrc` file in your project root or home directory. The configuration depends on your chosen provider:
 
+**For Ollama (local models):**
 ```ini
-ollama_url=http://localhost:11434
+provider=ollama
+base_url=http://localhost:11434
 model=devstral:latest
+temperature=0.1
+```
+
+**For OpenAI:**
+```ini
+provider=openai
+api_key=your_openai_api_key_here
+model=gpt-4
+temperature=0.1
+```
+
+**For Anthropic:**
+```ini
+provider=anthropic
+api_key=your_anthropic_api_key_here
+model=claude-3-sonnet-20240229
+temperature=0.1
 ```
 
 The tool will look for config files in this order:
@@ -62,8 +84,11 @@ The tool will look for config files in this order:
 
 You can also use environment variables:
 
-- `GOPR_OLLAMA_URL`
+- `GOPR_PROVIDER`
 - `GOPR_MODEL`
+- `GOPR_API_KEY`
+- `GOPR_BASE_URL`
+- `GOPR_TEMPERATURE`
 
 ## Usage
 
@@ -107,46 +132,66 @@ On Linux:
 
 Available options:
 
-- `-ollama-url`: Ollama server URL (default: from config or http://localhost:11434)
-- `-model`: Ollama model to use (default: from config or qwen2.5-coder:14b-instruct-q8_0)
-- `-branch`: Branch to compare current changes against to (default: `main`)
+- `-provider`: LLM provider (ollama, openai, anthropic)
+- `-model`: Model to use (varies by provider)
+- `-api-key`: API key for the provider (required for OpenAI/Anthropic)
+- `-base-url`: Base URL for the provider (optional, defaults vary by provider)
+- `-temperature`: Temperature for generation (default: 0.1)
+- `-branch`: Branch to compare current changes against (default: `main`)
 - `-verbose`: Enable verbose output for debugging
 
 ### Examples
 
-Use a different model:
-
+**Using Ollama (local models):**
 ```bash
-./gopr -model codellama
+./gopr -provider ollama -model codellama
 ```
 
-Enable verbose output:
+**Using OpenAI:**
+```bash
+./gopr -provider openai -model gpt-4 -api-key your_api_key_here
+```
 
+**Using Anthropic:**
+```bash
+./gopr -provider anthropic -model claude-3-sonnet-20240229 -api-key your_api_key_here
+```
+
+**Enable verbose output:**
 ```bash
 ./gopr -verbose
 ```
 
-Use a remote Ollama instance:
-
+**Use a remote Ollama instance:**
 ```bash
-./gopr -ollama-url http://192.168.1.100:11434
+./gopr -provider ollama -base-url http://192.168.1.100:11434
 ```
 
-Full command with all parameters provided:
-
+**Full command with all parameters:**
 ```bash
-gopr -model qwen2.5-coder:14b-instruct-q8_0 -ollama-url http://192.168.1.100:11434 -branch main -verbose true
+./gopr -provider openai -model gpt-4 -api-key your_key -temperature 0.1 -branch main -verbose
 ```
 
 ## Recommended Models
 
 Based on testing, these models perform best for PR description generation:
 
+### Ollama Models (Local)
 1. **devstral:latest** (23.6B) - Best accuracy and understanding of code changes
 2. **phi4:latest** (14.7B) - Good balance of size and accuracy
 3. **deepseek-coder-v2:latest** (15.7B) - Code-focused but may be less accurate
 4. **qwen2.5-coder:latest** (32B) - Large model, good accuracy but slower
 5. **qwen2.5-coder:14b-instruct-q8_0** (14B) - Good accuracy but slower
+
+### OpenAI Models
+1. **gpt-4** - Excellent code understanding and PR description quality
+2. **gpt-3.5-turbo** - Good performance with faster response times
+3. **gpt-4-turbo** - Best balance of quality and speed
+
+### Anthropic Models
+1. **claude-3-sonnet-20240229** - Excellent code analysis and PR descriptions
+2. **claude-3-haiku-20240307** - Fast and efficient for smaller changes
+3. **claude-3-opus-20240229** - Highest quality but slower responses
 
 ## How It Works
 
@@ -154,14 +199,15 @@ Based on testing, these models perform best for PR description generation:
 2. **Diff Generation**: Compares your current branch with main or `branch` using `git diff <branch>...`
 3. **Commit History**: Extracts commit messages since the desired branch
 4. **File Analysis**: Analyzes what types of files were changed
-5. **LLM Processing**: Formats the information and sends it to Ollama with low temperature (0.1)
+5. **LLM Processing**: Formats the information and sends it to the configured LLM provider with low temperature (0.1)
 6. **Response Validation**: Checks for generic responses and retries if needed
 7. **Output**: Returns a professional PR description in markdown format
 
 ## Project Structure
 
 - `cmd/main.go`: CLI entry point with config file support
-- `internal/service/`: Contains the PR generation logic and Ollama integration
+- `internal/models/`: Defines the LLM provider interface and configuration structures
+- `internal/service/`: Contains the PR generation logic and LLM provider implementations
 
 ## Contributing
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,20 +7,19 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
+	"github.com/deleonn/gopr/internal/models"
 	"github.com/deleonn/gopr/internal/service"
 )
 
-type Config struct {
-	OllamaURL string
-	Model     string
-}
-
-func loadConfig() Config {
-	config := Config{
-		OllamaURL: "http://msi_th.home:11434",
-		Model:     "qwen2.5-coder:14b-instruct-q8_0",
+func loadConfig() models.Config {
+	config := models.Config{
+		Provider:    models.ProviderOllama,
+		Model:       "qwen2.5-coder:14b-instruct-q8_0",
+		BaseURL:     "http://localhost:11434",
+		Temperature: 0.1,
 	}
 
 	// Try to load from .goprrc in current directory
@@ -43,7 +42,7 @@ func fileExists(filename string) bool {
 	return err == nil
 }
 
-func loadConfigFromFile(filename string, config *Config) {
+func loadConfigFromFile(filename string, config *models.Config) {
 	file, err := os.Open(filename)
 	if err != nil {
 		return
@@ -66,10 +65,18 @@ func loadConfigFromFile(filename string, config *Config) {
 		value := strings.TrimSpace(parts[1])
 
 		switch key {
-		case "ollama_url":
-			config.OllamaURL = value
+		case "provider":
+			config.Provider = models.ProviderType(value)
 		case "model":
 			config.Model = value
+		case "api_key":
+			config.APIKey = value
+		case "base_url":
+			config.BaseURL = value
+		case "temperature":
+			if temp, err := strconv.ParseFloat(value, 64); err == nil {
+				config.Temperature = temp
+			}
 		}
 	}
 }
@@ -79,14 +86,27 @@ func main() {
 
 	// Parse command line flags (these override config file)
 	var (
-		ollamaURL = flag.String("ollama-url", config.OllamaURL, "Ollama server URL")
-		model     = flag.String("model", config.Model, "Ollama model to use")
-		branch    = flag.String("branch", "main", "Branch for diff comparison")
-		verbose   = flag.Bool("verbose", false, "Enable verbose output")
+		provider    = flag.String("provider", string(config.Provider), "LLM provider (ollama, openai, anthropic)")
+		model       = flag.String("model", config.Model, "Model to use")
+		apiKey      = flag.String("api-key", config.APIKey, "API key for the provider")
+		baseURL     = flag.String("base-url", config.BaseURL, "Base URL for the provider")
+		temperature = flag.Float64("temperature", config.Temperature, "Temperature for generation")
+		branch      = flag.String("branch", "main", "Branch for diff comparison")
+		verbose     = flag.Bool("verbose", false, "Enable verbose output")
 	)
 	flag.Parse()
 
-	prService := service.NewPRService(*ollamaURL, *model, *branch)
+	// Override config with command line flags
+	config.Provider = models.ProviderType(*provider)
+	config.Model = *model
+	config.APIKey = *apiKey
+	config.BaseURL = *baseURL
+	config.Temperature = *temperature
+
+	prService, err := service.NewPRService(config, *branch)
+	if err != nil {
+		log.Fatalf("Failed to create PR service: %v", err)
+	}
 
 	description, err := prService.GeneratePRDescriptionFromBranch(*verbose)
 	if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -86,7 +86,7 @@ func main() {
 
 	// Parse command line flags (these override config file)
 	var (
-		provider    = flag.String("provider", string(config.Provider), "LLM provider (ollama, openai, anthropic)")
+		provider    = flag.String("provider", string(config.Provider), "LLM provider (ollama, openai, anthropic, deepseek)")
 		model       = flag.String("model", config.Model, "Model to use")
 		apiKey      = flag.String("api-key", config.APIKey, "API key for the provider")
 		baseURL     = flag.String("base-url", config.BaseURL, "Base URL for the provider")

--- a/example.goprrc
+++ b/example.goprrc
@@ -1,7 +1,7 @@
 # Example configuration file for gopr
 # Copy this to .goprrc in your project root or home directory
 
-# Choose your provider: ollama, openai, or anthropic
+# Choose your provider: ollama, openai, anthropic, or deepseek
 provider=ollama
 
 # Model to use (varies by provider)
@@ -27,6 +27,11 @@ temperature=0.1
 # provider=anthropic
 # model=claude-3-sonnet-20240229
 # api_key=sk-ant-your-anthropic-api-key-here
+
+# For DeepSeek:
+# provider=deepseek
+# model=deepseek-chat
+# api_key=your-deepseek-api-key-here
 
 # For remote Ollama:
 # provider=ollama

--- a/example.goprrc
+++ b/example.goprrc
@@ -1,0 +1,34 @@
+# Example configuration file for gopr
+# Copy this to .goprrc in your project root or home directory
+
+# Choose your provider: ollama, openai, or anthropic
+provider=ollama
+
+# Model to use (varies by provider)
+model=qwen2.5-coder:14b-instruct-q8_0
+
+# Base URL (for Ollama or custom OpenAI endpoints)
+base_url=http://localhost:11434
+
+# API Key (required for OpenAI and Anthropic)
+# api_key=your_api_key_here
+
+# Temperature for generation (0.0 to 1.0, lower = more focused)
+temperature=0.1
+
+# Examples for different providers:
+
+# For OpenAI:
+# provider=openai
+# model=gpt-4
+# api_key=sk-your-openai-api-key-here
+
+# For Anthropic:
+# provider=anthropic
+# model=claude-3-sonnet-20240229
+# api_key=sk-ant-your-anthropic-api-key-here
+
+# For remote Ollama:
+# provider=ollama
+# base_url=http://192.168.1.100:11434
+# model=devstral:latest 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,3 @@
 module github.com/deleonn/gopr
 
 go 1.23.3
-
-require (
-	github.com/gorilla/mux v1.8.1
-	github.com/joho/godotenv v1.5.1
-)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,0 @@
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
-github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
-github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -17,6 +17,7 @@ const (
 	ProviderOllama   ProviderType = "ollama"
 	ProviderOpenAI   ProviderType = "openai"
 	ProviderAnthropic ProviderType = "anthropic"
+	ProviderDeepSeek ProviderType = "deepseek"
 )
 
 // Config holds the configuration for the application
@@ -45,4 +46,11 @@ type OpenAIConfig struct {
 type AnthropicConfig struct {
 	APIKey string `json:"api_key"`
 	Model  string `json:"model"`
+}
+
+// DeepSeekConfig holds DeepSeek-specific configuration
+type DeepSeekConfig struct {
+	APIKey string `json:"api_key"`
+	Model  string `json:"model"`
+	BaseURL string `json:"base_url,omitempty"`
 } 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,0 +1,48 @@
+package models
+
+import (
+	"context"
+)
+
+// LLMProvider defines the interface for different LLM providers
+type LLMProvider interface {
+	GenerateResponse(ctx context.Context, prompt string, temperature float64) (string, error)
+	GetName() string
+}
+
+// ProviderType represents the type of LLM provider
+type ProviderType string
+
+const (
+	ProviderOllama   ProviderType = "ollama"
+	ProviderOpenAI   ProviderType = "openai"
+	ProviderAnthropic ProviderType = "anthropic"
+)
+
+// Config holds the configuration for the application
+type Config struct {
+	Provider   ProviderType `json:"provider"`
+	Model      string       `json:"model"`
+	APIKey     string       `json:"api_key,omitempty"`
+	BaseURL    string       `json:"base_url,omitempty"`
+	Temperature float64      `json:"temperature"`
+}
+
+// OllamaConfig holds Ollama-specific configuration
+type OllamaConfig struct {
+	BaseURL string `json:"base_url"`
+	Model   string `json:"model"`
+}
+
+// OpenAIConfig holds OpenAI-specific configuration
+type OpenAIConfig struct {
+	APIKey string `json:"api_key"`
+	Model  string `json:"model"`
+	BaseURL string `json:"base_url,omitempty"`
+}
+
+// AnthropicConfig holds Anthropic-specific configuration
+type AnthropicConfig struct {
+	APIKey string `json:"api_key"`
+	Model  string `json:"model"`
+} 

--- a/internal/service/anthropic_provider.go
+++ b/internal/service/anthropic_provider.go
@@ -1,0 +1,85 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/deleonn/gopr/internal/models"
+)
+
+type AnthropicProvider struct {
+	apiKey string
+	model  string
+}
+
+func NewAnthropicProvider(config models.AnthropicConfig) *AnthropicProvider {
+	return &AnthropicProvider{
+		apiKey: config.APIKey,
+		model:  config.Model,
+	}
+}
+
+func (a *AnthropicProvider) GetName() string {
+	return "Anthropic"
+}
+
+func (a *AnthropicProvider) GenerateResponse(ctx context.Context, prompt string, temperature float64) (string, error) {
+	requestBody := map[string]any{
+		"model":       a.model,
+		"messages":    []map[string]string{{"role": "user", "content": prompt}},
+		"temperature": temperature,
+		"max_tokens":  4000,
+	}
+
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request body: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", "https://api.anthropic.com/v1/messages", bytes.NewBuffer(body))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("x-api-key", a.apiKey)
+	httpReq.Header.Set("anthropic-version", "2023-06-01")
+
+	client := &http.Client{
+		Timeout: 60 * time.Second,
+	}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	content, ok := result["content"].([]any)
+	if !ok || len(content) == 0 {
+		return "", fmt.Errorf("invalid response format: no content")
+	}
+
+	firstContent, ok := content[0].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("invalid response format: invalid content")
+	}
+
+	text, ok := firstContent["text"].(string)
+	if !ok {
+		return "", fmt.Errorf("invalid response format: no text")
+	}
+
+	return text, nil
+} 

--- a/internal/service/deepseek_provider.go
+++ b/internal/service/deepseek_provider.go
@@ -1,0 +1,96 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/deleonn/gopr/internal/models"
+)
+
+type DeepSeekProvider struct {
+	apiKey  string
+	model   string
+	baseURL string
+}
+
+func NewDeepSeekProvider(config models.DeepSeekConfig) *DeepSeekProvider {
+	baseURL := config.BaseURL
+	if baseURL == "" {
+		baseURL = "https://api.deepseek.com/v1"
+	}
+
+	return &DeepSeekProvider{
+		apiKey:  config.APIKey,
+		model:   config.Model,
+		baseURL: baseURL,
+	}
+}
+
+func (d *DeepSeekProvider) GetName() string {
+	return "DeepSeek"
+}
+
+func (d *DeepSeekProvider) GenerateResponse(ctx context.Context, prompt string, temperature float64) (string, error) {
+	requestBody := map[string]any{
+		"model":       d.model,
+		"messages":    []map[string]string{{"role": "user", "content": prompt}},
+		"temperature": temperature,
+		"max_tokens":  4000,
+	}
+
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request body: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", d.baseURL+"/chat/completions", bytes.NewBuffer(body))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+d.apiKey)
+
+	client := &http.Client{
+		Timeout: 60 * time.Second,
+	}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	choices, ok := result["choices"].([]any)
+	if !ok || len(choices) == 0 {
+		return "", fmt.Errorf("invalid response format: no choices")
+	}
+
+	choice, ok := choices[0].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("invalid response format: invalid choice")
+	}
+
+	message, ok := choice["message"].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("invalid response format: no message")
+	}
+
+	content, ok := message["content"].(string)
+	if !ok {
+		return "", fmt.Errorf("invalid response format: no content")
+	}
+
+	return content, nil
+} 

--- a/internal/service/ollama_provider.go
+++ b/internal/service/ollama_provider.go
@@ -1,0 +1,73 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/deleonn/gopr/internal/models"
+)
+
+type OllamaProvider struct {
+	baseURL string
+	model   string
+}
+
+func NewOllamaProvider(config models.OllamaConfig) *OllamaProvider {
+	return &OllamaProvider{
+		baseURL: config.BaseURL,
+		model:   config.Model,
+	}
+}
+
+func (o *OllamaProvider) GetName() string {
+	return "Ollama"
+}
+
+func (o *OllamaProvider) GenerateResponse(ctx context.Context, prompt string, temperature float64) (string, error) {
+	requestBody := map[string]any{
+		"model":       o.model,
+		"prompt":      prompt,
+		"stream":      false,
+		"temperature": temperature,
+	}
+
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request body: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", o.baseURL+"/api/generate", bytes.NewBuffer(body))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{
+		Timeout: 60 * time.Second,
+	}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	response, ok := result["response"].(string)
+	if !ok {
+		return "", fmt.Errorf("invalid response format")
+	}
+
+	return response, nil
+} 

--- a/internal/service/openai_provider.go
+++ b/internal/service/openai_provider.go
@@ -1,0 +1,96 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/deleonn/gopr/internal/models"
+)
+
+type OpenAIProvider struct {
+	apiKey  string
+	model   string
+	baseURL string
+}
+
+func NewOpenAIProvider(config models.OpenAIConfig) *OpenAIProvider {
+	baseURL := config.BaseURL
+	if baseURL == "" {
+		baseURL = "https://api.openai.com/v1"
+	}
+
+	return &OpenAIProvider{
+		apiKey:  config.APIKey,
+		model:   config.Model,
+		baseURL: baseURL,
+	}
+}
+
+func (o *OpenAIProvider) GetName() string {
+	return "OpenAI"
+}
+
+func (o *OpenAIProvider) GenerateResponse(ctx context.Context, prompt string, temperature float64) (string, error) {
+	requestBody := map[string]any{
+		"model":       o.model,
+		"messages":    []map[string]string{{"role": "user", "content": prompt}},
+		"temperature": temperature,
+		"max_tokens":  4000,
+	}
+
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request body: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", o.baseURL+"/chat/completions", bytes.NewBuffer(body))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
+
+	client := &http.Client{
+		Timeout: 60 * time.Second,
+	}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	choices, ok := result["choices"].([]any)
+	if !ok || len(choices) == 0 {
+		return "", fmt.Errorf("invalid response format: no choices")
+	}
+
+	choice, ok := choices[0].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("invalid response format: invalid choice")
+	}
+
+	message, ok := choice["message"].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("invalid response format: no message")
+	}
+
+	content, ok := message["content"].(string)
+	if !ok {
+		return "", fmt.Errorf("invalid response format: no content")
+	}
+
+	return content, nil
+} 

--- a/internal/service/provider_factory.go
+++ b/internal/service/provider_factory.go
@@ -44,6 +44,17 @@ func (f *ProviderFactory) CreateProvider(config models.Config) (models.LLMProvid
 		}
 		return NewAnthropicProvider(anthropicConfig), nil
 
+	case models.ProviderDeepSeek:
+		if config.APIKey == "" {
+			return nil, fmt.Errorf("API key is required for DeepSeek provider")
+		}
+		deepSeekConfig := models.DeepSeekConfig{
+			APIKey:  config.APIKey,
+			Model:   config.Model,
+			BaseURL: config.BaseURL,
+		}
+		return NewDeepSeekProvider(deepSeekConfig), nil
+
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", config.Provider)
 	}

--- a/internal/service/provider_factory.go
+++ b/internal/service/provider_factory.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/deleonn/gopr/internal/models"
+)
+
+// ProviderFactory creates LLM providers based on configuration
+type ProviderFactory struct{}
+
+func NewProviderFactory() *ProviderFactory {
+	return &ProviderFactory{}
+}
+
+// CreateProvider creates a new LLM provider based on the configuration
+func (f *ProviderFactory) CreateProvider(config models.Config) (models.LLMProvider, error) {
+	switch config.Provider {
+	case models.ProviderOllama:
+		ollamaConfig := models.OllamaConfig{
+			BaseURL: config.BaseURL,
+			Model:   config.Model,
+		}
+		return NewOllamaProvider(ollamaConfig), nil
+
+	case models.ProviderOpenAI:
+		if config.APIKey == "" {
+			return nil, fmt.Errorf("API key is required for OpenAI provider")
+		}
+		openAIConfig := models.OpenAIConfig{
+			APIKey:  config.APIKey,
+			Model:   config.Model,
+			BaseURL: config.BaseURL,
+		}
+		return NewOpenAIProvider(openAIConfig), nil
+
+	case models.ProviderAnthropic:
+		if config.APIKey == "" {
+			return nil, fmt.Errorf("API key is required for Anthropic provider")
+		}
+		anthropicConfig := models.AnthropicConfig{
+			APIKey: config.APIKey,
+			Model:  config.Model,
+		}
+		return NewAnthropicProvider(anthropicConfig), nil
+
+	default:
+		return nil, fmt.Errorf("unsupported provider: %s", config.Provider)
+	}
+} 


### PR DESCRIPTION
# TL;DR

Refactor the PRService to support multiple LLM providers (Ollama, OpenAI, Anthropic, DeepSeek) instead of being hardcoded to use Ollama. Added a new ProviderFactory to create provider instances based on configuration.

# What's changed?

- Refactored `pr_service.go` to accept a `models.LLMProvider` instead of specific Ollama parameters.
- Introduced `provider_factory.go` to handle the creation of different LLM providers based on configuration.
- Added new provider implementations: `anthropic_provider.go`, `deepseek_provider.go`, and `openai_provider.go`.
- Modified `models/config.go` to include support for different providers and their configurations.
- Updated `main.go` to use the new ProviderFactory.

# How to test?

1. Update your configuration file with the desired provider (e.g., OpenAI) and its corresponding API key and model.
2. Run the application and ensure it generates PR descriptions using the selected LLM provider.

# Why make this change?

To increase flexibility and support for multiple large language models, allowing users to choose their preferred provider without modifying the core PRService logic.

# Breaking changes or important notes

- The configuration format has changed to include a `provider` field specifying which LLM provider to use.
- Users must now provide an API key for providers that require it (e.g., OpenAI, Anthropic, DeepSeek).
