### PR TITLE
fix/broken-providers

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,9 +16,6 @@ import (
 
 func loadConfig() models.Config {
 	config := models.Config{
-		Provider:    models.ProviderOllama,
-		Model:       "qwen2.5-coder:14b-instruct-q8_0",
-		BaseURL:     "http://localhost:11434",
 		Temperature: 0.1,
 	}
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -8,24 +8,25 @@ import (
 type LLMProvider interface {
 	GenerateResponse(ctx context.Context, prompt string, temperature float64) (string, error)
 	GetName() string
+	GetModel() string
 }
 
 // ProviderType represents the type of LLM provider
 type ProviderType string
 
 const (
-	ProviderOllama   ProviderType = "ollama"
-	ProviderOpenAI   ProviderType = "openai"
+	ProviderOllama    ProviderType = "ollama"
+	ProviderOpenAI    ProviderType = "openai"
 	ProviderAnthropic ProviderType = "anthropic"
-	ProviderDeepSeek ProviderType = "deepseek"
+	ProviderDeepSeek  ProviderType = "deepseek"
 )
 
 // Config holds the configuration for the application
 type Config struct {
-	Provider   ProviderType `json:"provider"`
-	Model      string       `json:"model"`
-	APIKey     string       `json:"api_key,omitempty"`
-	BaseURL    string       `json:"base_url,omitempty"`
+	Provider    ProviderType `json:"provider"`
+	Model       string       `json:"model"`
+	APIKey      string       `json:"api_key,omitempty"`
+	BaseURL     string       `json:"base_url,omitempty"`
 	Temperature float64      `json:"temperature"`
 }
 
@@ -37,8 +38,8 @@ type OllamaConfig struct {
 
 // OpenAIConfig holds OpenAI-specific configuration
 type OpenAIConfig struct {
-	APIKey string `json:"api_key"`
-	Model  string `json:"model"`
+	APIKey  string `json:"api_key"`
+	Model   string `json:"model"`
 	BaseURL string `json:"base_url,omitempty"`
 }
 
@@ -50,7 +51,8 @@ type AnthropicConfig struct {
 
 // DeepSeekConfig holds DeepSeek-specific configuration
 type DeepSeekConfig struct {
-	APIKey string `json:"api_key"`
-	Model  string `json:"model"`
+	APIKey  string `json:"api_key"`
+	Model   string `json:"model"`
 	BaseURL string `json:"base_url,omitempty"`
-} 
+}
+

--- a/internal/service/anthropic_provider.go
+++ b/internal/service/anthropic_provider.go
@@ -29,6 +29,10 @@ func NewAnthropicProvider(config models.AnthropicConfig) *AnthropicProvider {
 	}
 }
 
+func (a *AnthropicProvider) GetModel() string {
+	return a.model
+}
+
 func (a *AnthropicProvider) GetName() string {
 	return "Anthropic"
 }

--- a/internal/service/anthropic_provider.go
+++ b/internal/service/anthropic_provider.go
@@ -17,9 +17,15 @@ type AnthropicProvider struct {
 }
 
 func NewAnthropicProvider(config models.AnthropicConfig) *AnthropicProvider {
+	model := config.Model
+
+	if model == "" {
+		model = "claude-3-sonnet-20240229"
+	}
+
 	return &AnthropicProvider{
 		apiKey: config.APIKey,
-		model:  config.Model,
+		model:  model,
 	}
 }
 
@@ -82,4 +88,5 @@ func (a *AnthropicProvider) GenerateResponse(ctx context.Context, prompt string,
 	}
 
 	return text, nil
-} 
+}
+

--- a/internal/service/deepseek_provider.go
+++ b/internal/service/deepseek_provider.go
@@ -30,6 +30,10 @@ func NewDeepSeekProvider(config models.DeepSeekConfig) *DeepSeekProvider {
 	}
 }
 
+func (d *DeepSeekProvider) GetModel() string {
+	return d.model
+}
+
 func (d *DeepSeekProvider) GetName() string {
 	return "DeepSeek"
 }

--- a/internal/service/deepseek_provider.go
+++ b/internal/service/deepseek_provider.go
@@ -18,15 +18,15 @@ type DeepSeekProvider struct {
 }
 
 func NewDeepSeekProvider(config models.DeepSeekConfig) *DeepSeekProvider {
-	baseURL := config.BaseURL
-	if baseURL == "" {
-		baseURL = "https://api.deepseek.com/v1"
+	model := config.Model
+
+	if model == "" {
+		model = "deepseek-chat"
 	}
 
 	return &DeepSeekProvider{
-		apiKey:  config.APIKey,
-		model:   config.Model,
-		baseURL: baseURL,
+		apiKey: config.APIKey,
+		model:  model,
 	}
 }
 
@@ -47,7 +47,7 @@ func (d *DeepSeekProvider) GenerateResponse(ctx context.Context, prompt string, 
 		return "", fmt.Errorf("failed to marshal request body: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", d.baseURL+"/chat/completions", bytes.NewBuffer(body))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", "https://api.deepseek.com/v1/chat/completions", bytes.NewBuffer(body))
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}
@@ -93,4 +93,4 @@ func (d *DeepSeekProvider) GenerateResponse(ctx context.Context, prompt string, 
 	}
 
 	return content, nil
-} 
+}

--- a/internal/service/ollama_provider.go
+++ b/internal/service/ollama_provider.go
@@ -33,6 +33,10 @@ func NewOllamaProvider(config models.OllamaConfig) *OllamaProvider {
 	}
 }
 
+func (o *OllamaProvider) GetModel() string {
+	return o.model
+}
+
 func (o *OllamaProvider) GetName() string {
 	return "Ollama"
 }

--- a/internal/service/ollama_provider.go
+++ b/internal/service/ollama_provider.go
@@ -17,9 +17,19 @@ type OllamaProvider struct {
 }
 
 func NewOllamaProvider(config models.OllamaConfig) *OllamaProvider {
+	baseURL := config.BaseURL
+	if baseURL == "" {
+		baseURL = "http://localhost:11434"
+	}
+
+	model := config.Model
+	if model == "" {
+		model = "qwen2.5-coder:14b-instruct-q8_0"
+	}
+
 	return &OllamaProvider{
-		baseURL: config.BaseURL,
-		model:   config.Model,
+		baseURL: baseURL,
+		model:   model,
 	}
 }
 
@@ -70,4 +80,5 @@ func (o *OllamaProvider) GenerateResponse(ctx context.Context, prompt string, te
 	}
 
 	return response, nil
-} 
+}
+

--- a/internal/service/openai_provider.go
+++ b/internal/service/openai_provider.go
@@ -18,15 +18,15 @@ type OpenAIProvider struct {
 }
 
 func NewOpenAIProvider(config models.OpenAIConfig) *OpenAIProvider {
-	baseURL := config.BaseURL
-	if baseURL == "" {
-		baseURL = "https://api.openai.com/v1"
+	model := config.Model
+
+	if model == "" {
+		model = "gpt-4"
 	}
 
 	return &OpenAIProvider{
-		apiKey:  config.APIKey,
-		model:   config.Model,
-		baseURL: baseURL,
+		apiKey: config.APIKey,
+		model:  config.Model,
 	}
 }
 
@@ -47,7 +47,7 @@ func (o *OpenAIProvider) GenerateResponse(ctx context.Context, prompt string, te
 		return "", fmt.Errorf("failed to marshal request body: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", o.baseURL+"/chat/completions", bytes.NewBuffer(body))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", "https://api.openapi.com/v1/chat/completions", bytes.NewBuffer(body))
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}
@@ -93,4 +93,5 @@ func (o *OpenAIProvider) GenerateResponse(ctx context.Context, prompt string, te
 	}
 
 	return content, nil
-} 
+}
+

--- a/internal/service/openai_provider.go
+++ b/internal/service/openai_provider.go
@@ -30,6 +30,10 @@ func NewOpenAIProvider(config models.OpenAIConfig) *OpenAIProvider {
 	}
 }
 
+func (o *OpenAIProvider) GetModel() string {
+	return o.model
+}
+
 func (o *OpenAIProvider) GetName() string {
 	return "OpenAI"
 }

--- a/internal/service/pr_service.go
+++ b/internal/service/pr_service.go
@@ -38,6 +38,11 @@ func (s *PRService) GeneratePRDescriptionFromBranch(verbose bool) (string, error
 	}
 
 	if verbose {
+		fmt.Fprintf(os.Stderr, "Current provider: %s\n", s.provider.GetName())
+		fmt.Fprintf(os.Stderr, "Current model: %s\n", s.provider.GetModel())
+	}
+
+	if verbose {
 		fmt.Fprintf(os.Stderr, "Current branch: %s\n", currentBranch)
 	}
 

--- a/internal/service/provider_factory.go
+++ b/internal/service/provider_factory.go
@@ -28,9 +28,8 @@ func (f *ProviderFactory) CreateProvider(config models.Config) (models.LLMProvid
 			return nil, fmt.Errorf("API key is required for OpenAI provider")
 		}
 		openAIConfig := models.OpenAIConfig{
-			APIKey:  config.APIKey,
-			Model:   config.Model,
-			BaseURL: config.BaseURL,
+			APIKey: config.APIKey,
+			Model:  config.Model,
 		}
 		return NewOpenAIProvider(openAIConfig), nil
 
@@ -49,13 +48,12 @@ func (f *ProviderFactory) CreateProvider(config models.Config) (models.LLMProvid
 			return nil, fmt.Errorf("API key is required for DeepSeek provider")
 		}
 		deepSeekConfig := models.DeepSeekConfig{
-			APIKey:  config.APIKey,
-			Model:   config.Model,
-			BaseURL: config.BaseURL,
+			APIKey: config.APIKey,
+			Model:  config.Model,
 		}
 		return NewDeepSeekProvider(deepSeekConfig), nil
 
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", config.Provider)
 	}
-} 
+}


### PR DESCRIPTION
# TL;DR

This PR addresses issues with provider configurations and adds verbose output for the current provider and model.

# What's changed?

- Removed hardcoded provider and model from `cmd/main.go`.
- Added a new method `GetModel()` to the `LLMProvider` interface in `internal/models/models.go`.
- Implemented the `GetModel()` method in provider-specific files: `anthropic_provider.go`, `deepseek_provider.go`, `ollama_provider.go`, and `openai_provider.go`.
- Modified provider creation logic to use default models if none are specified.
- Updated `pr_service.go` to include verbose output for the current provider and model.

# How to test?

1. Run the application with a configuration file that specifies different providers and models.
2. Verify that the correct provider and model are displayed in verbose mode.
3. Ensure that default models are used when none are specified in the configuration.

# Why make this change?

- To allow for more flexibility in specifying provider configurations.
- To provide clearer debugging information by displaying the current provider and model during execution.

# Breaking changes or important notes

- The removal of hardcoded provider and model in `cmd/main.go` may require updates to existing configurations.
- Ensure that all providers have default models defined to avoid runtime errors.
